### PR TITLE
Build on Python 3.11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - name: Checkout
@@ -43,7 +43,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.8.1
         env:
-          CIBW_BUILD: cp{36,37,38,39,310}-manylinux_x86_64
+          CIBW_BUILD: cp{36,37,38,39,310,311}-manylinux_x86_64
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - name: Checkout
@@ -43,7 +43,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.8.1
         env:
-          CIBW_BUILD: cp{36,37,38,39,310,311}-manylinux_x86_64
+          CIBW_BUILD: cp{37,38,39,310,311}-manylinux_x86_64
 
       - uses: actions/upload-artifact@v3
         with:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,3 @@
 include README.md
+include src/condat_gridconv/*.pyx
+exclude src/condat_gridconv/*.c

--- a/setup.py
+++ b/setup.py
@@ -19,4 +19,5 @@ setup(
     install_requires=[
         'numpy',
     ],
+    python_requires='>=3.7',
 )

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import setup
 from Cython.Build import cythonize
 
 with open("README.md") as f:
@@ -12,6 +12,7 @@ setup(
     description="Convert data from hexagonal pixels to cartesian grid",
     long_description=readme,
     long_description_content_type='text/markdown',
+    url="https://github.com/European-XFEL/condat-gridconv",
     package_dir={"": "src"},
     packages=["condat_gridconv"],
     ext_modules = cythonize("src/condat_gridconv/shift.pyx"),


### PR DESCRIPTION
Also include the `.pyx` file and exclude the `.c` file from the sdist; this makes it more likely that future versions of Python can use it (because a new version of Cython can generate the C code).